### PR TITLE
修复: 网站设置 root 后，阅读剩下更多 按钮 404 问题

### DIFF
--- a/layout/_partial/archive-post.ejs
+++ b/layout/_partial/archive-post.ejs
@@ -33,7 +33,7 @@
                 <%- post.blogexcerpt || post.excerpt || post.content %>
             <% } %>
             <p class="more">
-                <a href="<%- post.permalink %>">阅读剩下更多</a>
+                <a href="<%- url_for(post.permalink) %>">阅读剩下更多</a>
             </p>
         </div>
         <div class="post-thumbnail" data-img="<%- post.photos[0] %>">


### PR DESCRIPTION
当网站设置 root 后，“阅读剩下更多" 按钮点击出现 404。
如设置 root 为 hexo、网站为：http://test.com/hexo 。
文章链接为 http://test.com/hexo/abc.html。而点击 按钮则跳至 http://test.com/abc.html
，出现 404报错。